### PR TITLE
fix: publish dashboard from docs/ after folder move

### DIFF
--- a/.github/workflows/ecosystem-test.yml
+++ b/.github/workflows/ecosystem-test.yml
@@ -319,15 +319,15 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           changed=false
-          if [ ! -f dashboard/dashboard.json ]; then
-            echo "dashboard/dashboard.json missing — nothing to publish"
+          if [ ! -f docs/dashboard.json ]; then
+            echo "docs/dashboard.json missing — nothing to publish"
           else
-            CURR=$(jq -S 'del(.lastUpdated)' dashboard/dashboard.json 2>/dev/null || echo '')
-            PREV=$(git show HEAD:dashboard/dashboard.json 2>/dev/null \
+            CURR=$(jq -S 'del(.lastUpdated)' docs/dashboard.json 2>/dev/null || echo '')
+            PREV=$(git show HEAD:docs/dashboard.json 2>/dev/null \
                      | jq -S 'del(.lastUpdated)' 2>/dev/null || echo '')
             if [ "$CURR" = "$PREV" ]; then
               echo "No meaningful change (lastUpdated ignored) — discarding timestamp-only churn"
-              git checkout -- dashboard/dashboard.json 2>/dev/null || true
+              git checkout -- docs/dashboard.json 2>/dev/null || true
             else
               echo "Dashboard changed — will publish"
               changed=true
@@ -350,7 +350,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add dashboard/dashboard.json
+          git add docs/dashboard.json
           git commit -m "chore: update dashboard.json [skip ci]"
           git push origin "HEAD:${BRANCH}"
 
@@ -363,14 +363,14 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           branch: automated/dashboard-update
           delete-branch: true
-          add-paths: dashboard/dashboard.json
+          add-paths: docs/dashboard.json
           title: "chore: update dashboard.json"
           commit-message: "chore: update dashboard.json [skip ci]"
           body: |
             ## Automated dashboard update
 
             The ecosystem CI detected a change in the cross-check matrix.
-            This PR updates `dashboard/dashboard.json` (the `lastUpdated`
+            This PR updates `docs/dashboard.json` (the `lastUpdated`
             timestamp alone never triggers it).
 
             ---

--- a/docs/dashboard.json
+++ b/docs/dashboard.json
@@ -1,8 +1,8 @@
 {
-  "lastUpdated": "2026-06-01T12:41:26Z",
+  "lastUpdated": "2026-07-27T13:05:03Z",
   "testSummary": {
-    "total": 105,
-    "passed": 105,
+    "total": 100,
+    "passed": 100,
     "failed": 0,
     "skipped": 0,
     "successRate": 1.00
@@ -225,15 +225,15 @@
     {
       "name": "payment-splitter",
       "aiken": "passed",
-      "scalus": "passed",
+      "scalus": "not-implemented",
       "ccl-java+aiken": "passed",
-      "ccl-java+scalus": "passed",
+      "ccl-java+scalus": "not-implemented",
       "meshjs+aiken": "passed",
-      "meshjs+scalus": "passed",
+      "meshjs+scalus": "not-implemented",
       "evolutionsdk+aiken": "passed",
-      "evolutionsdk+scalus": "passed",
+      "evolutionsdk+scalus": "not-implemented",
       "pycardano+aiken": "passed",
-      "pycardano+scalus": "passed"
+      "pycardano+scalus": "not-implemented"
     },
     {
       "name": "pricebet",
@@ -353,16 +353,21 @@
       "pycardano": "0.19.2"
     },
     "latest": {
-      "aiken-compiler": "v1.1.22",
+      "aiken-compiler": "v1.1.23",
       "aiken-lang/stdlib": "v3.1.0",
       "sidan-lab/vodka": "0.1.23",
-      "@meshsdk/core": "1.9.0",
-      "@meshsdk/core-csl": "1.9.0",
-      "@meshsdk/common": "1.9.0",
+      "@meshsdk/core": "1.9.1",
+      "@meshsdk/core-csl": "1.9.1",
+      "@meshsdk/common": "1.9.1",
       "@evolution-sdk/lucid": "2.0.1",
       "cardano-client-lib": "0.8.0-pre4",
       "pycardano": "0.19.2"
     },
-    "outdated": []
+    "outdated": [
+      "aiken-compiler",
+      "@meshsdk/core",
+      "@meshsdk/core-csl",
+      "@meshsdk/common"
+    ]
   }
 }


### PR DESCRIPTION
The dashboard output moved from `dashboard/` to `docs/` in d0967fd, but the publish steps in `ecosystem-test.yml` still point at the old path. Since those steps are `continue-on-error`, every run silently skipped publishing — the public dashboard hasn't updated since June 1 while CI stayed green.

This updates the path references to `docs/dashboard.json`. No logic changes.

About the second commit: with the path fixed, this branch's own CI run exercised the publish step and committed a refreshed `docs/dashboard.json` here (on non-main branches the workflow commits directly — its intended behavior), so merging this also brings the dashboard current. That bot commit is tagged `[skip ci]`, which is why the PR head shows no checks — the code commit's full pipeline ran green twice.

One content note on the refreshed data: the only Scalus cell that changes is `payment-splitter` (`passed` → `not-implemented`), which is correct — its `onchain/scalus/` project was removed in #54 when the Scalus work moved to `fullstack/scalus/`. Those fullstack implementations aren't covered by discovery/CI yet, so Scalus intentionally still shows as implemented only for `auction`; wiring `fullstack/scalus/` into the cross-check is a separate follow-up.