### PR TITLE
fix: align workflow aiken pin with versions.json and keep it synced

### DIFF
--- a/.github/workflows/ecosystem-test.yml
+++ b/.github/workflows/ecosystem-test.yml
@@ -38,7 +38,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AIKEN_VERSION: v1.1.21
+  AIKEN_VERSION: v1.1.22
   SCALUS_JAVA_VERSION: '21'
   CACHE_VERSION: v1
 
@@ -117,7 +117,7 @@ jobs:
     uses: ./.github/workflows/_compile-aiken.yml
     with:
       examples:      ${{ needs.discover.outputs.aiken-examples }}
-      aiken-version: v1.1.21
+      aiken-version: v1.1.22
       cache-version: v1
 
   compile-scalus:

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -137,6 +137,41 @@ done < <(find "$REPO_ROOT" -name "aiken.toml" -not -path "*/build/*" -print0 | s
 
 echo ""
 
+# ── 1b. Aiken pin in the CI workflow ───────────────────────────────────────────
+# ecosystem-test.yml pins aiken twice: env.AIKEN_VERSION, and a literal in
+# compile-aiken's `with:` block (reusable-workflow inputs cannot read env).
+echo "=== Updating workflow aiken pin ==="
+
+WORKFLOW_FILE="$REPO_ROOT/.github/workflows/ecosystem-test.yml"
+
+update_workflow_pin() {
+  local key="$1"        # e.g. "AIKEN_VERSION:" or "aiken-version:"
+  local target_ver="$2"
+
+  # Only lines with a literal version (skips `aiken-version: ${{ env... }}`)
+  local current_ver
+  current_ver=$(grep -E "${key} *v[0-9]" "$WORKFLOW_FILE" | head -1 | sed -E "s|.*${key} *||" | tr -d '[:space:]' || true)
+
+  if [ -z "$current_ver" ]; then
+    return 0
+  fi
+
+  if [ "$current_ver" = "$target_ver" ]; then
+    echo -e "  ${YELLOW}[SKIP]${NC}    ${key} already up to date in $(basename "$WORKFLOW_FILE") ($WORKFLOW_FILE)"
+  elif [ "$CHECK_MODE" = true ]; then
+    echo -e "  ${RED}[DRIFT]${NC}   ${key} has '$current_ver', want '$target_ver' in $WORKFLOW_FILE"
+    DRIFTED_FILES+=("$WORKFLOW_FILE")
+  else
+    sed_inplace "$WORKFLOW_FILE" "s|(${key} *)v[0-9][^[:space:]]*|\1${target_ver}|"
+    echo -e "  ${GREEN}[UPDATED]${NC} ${key} in $(basename "$WORKFLOW_FILE") ($WORKFLOW_FILE)"
+  fi
+}
+
+update_workflow_pin "AIKEN_VERSION:" "$AIKEN_COMPILER"
+update_workflow_pin "aiken-version:" "$AIKEN_COMPILER"
+
+echo ""
+
 # ── 2. Mesh.js deno.json files ─────────────────────────────────────────────────
 # Updates @meshsdk/core, @meshsdk/core-csl, @meshsdk/common.
 # Does NOT touch @meshsdk/core-cst (a different package, not in versions.json).


### PR DESCRIPTION
`versions.json` pins aiken v1.1.22, but the workflow still hardcodes v1.1.21 in two places (`env.AIKEN_VERSION`, and a literal in `compile-aiken` since reusable-workflow inputs can't read env). `sync-versions.sh` didn't cover the workflow, so the pin would just drift again on the next bump.

This adds a workflow-pin section to `sync-versions.sh` (with `--check` support) and applies the bump — the workflow diff here was generated by running the script.