### PR TITLE
docs: fix stale repo links, CI instructions, and README link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 First off, thanks for taking the time to contribute! 🎉
 
-When contributing to this repository, please first describe the change you wish to make [via an issue](https://github.com/cardano-foundation/cardano-blueprint-and-ecosystem-monitoring/issues/new) before making a change. For every other form of discussion use the [discussions section](https://github.com/cardano-foundation/cardano-blueprint-and-ecosystem-monitoring/discussions) of this repo.
-Please note we have a [code of conduct](https://github.com/cardano-foundation/cardano-blueprint-and-ecosystem-monitoring/blob/main/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+When contributing to this repository, please first describe the change you wish to make [via an issue](https://github.com/cardano-foundation/cardano-templates/issues/new) before making a change. For every other form of discussion use the [discussions section](https://github.com/cardano-foundation/cardano-templates/discussions) of this repo.
+Please note we have a [code of conduct](https://github.com/cardano-foundation/cardano-templates/blob/main/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
 ## Development
 
@@ -23,7 +23,7 @@ The pipeline (discovery, dashboard, version checks) is driven by a single regist
    ```
    The discovery script will start scanning for `*/onchain/<dir>/<manifest-file>` and the dashboard will add a column automatically. `statusPrefix` is what shows up in `.local-test-results/<prefix>-<example>-status.txt` and in the GitHub Actions artifact name (`logs-<prefix>-...`); keep it short and stable.
 
-2. **Add a CI job to `.github/workflows/ecosystem-test.yml`**: copy one of the existing `test-*` jobs (or `compile-aiken` for a compile-only on-chain job) and adapt the toolchain setup, run command, working directory, and artifact name. There's a comment block above `test-lucid` with the full checklist.
+2. **Touch the CI plumbing only for a new runtime or on-chain language**: an off-chain framework on an existing runtime (`deno`/`jbang`/`python`) needs **no workflow changes** — the test matrix is computed from `frameworks.json` automatically. A genuinely new runtime adds one conditional setup step to `.github/workflows/_test-offchain.yml` (plus a `case` in `scripts/local-test-offchain.sh`); a new on-chain language adds one `compile-<id>` job to `ecosystem-test.yml`. The full walkthrough, including scaffolding skeleton entry files with `scripts/scaffold-offchain.sh`, lives in [docs/ADDING-A-LIBRARY.md](docs/ADDING-A-LIBRARY.md).
 
 3. **(Optional) Add library version pins**: if your framework uses pinned upstream libraries you want tracked, add them to `versions.json` and a corresponding section in `scripts/sync-versions.sh` and `scripts/check-library-versions.sh`. (You can skip this if you only want the framework to appear in the matrix and have CI run its tests.)
 
@@ -39,15 +39,15 @@ cd docs && python3 -m http.server 8000 # then open http://localhost:8000
 
 ### Bug reports
 
-[Submit an issue](https://github.com/cardano-foundation/cardano-blueprint-and-ecosystem-monitoring/issues/new) using the provided template for bug reports. If the template does not fit your purpose start with a blank issue.
+[Submit an issue](https://github.com/cardano-foundation/cardano-templates/issues/new) describing the bug.
 
-For bug reports, it's very important to fill in the information in the structure provided by the templates to help us analyzing the bug.
+For bug reports, it's very important to include what you did, what you expected, and what actually happened — plus environment details (OS, toolchain versions) — to help us analyze the bug.
 
 ### Feature requests and ideas
 
-[Submit an issue](https://github.com/cardano-foundation/cardano-blueprint-and-ecosystem-monitoring/issues/new) using the provided template for feature requests. If the template does not fit your purpose start with a blank issue but make sure the name starts with a "FEATURE" in square brackets.
+[Submit an issue](https://github.com/cardano-foundation/cardano-templates/issues/new) and make sure the name starts with a "FEATURE" in square brackets.
 
-If you are starting with a very vague idea instead of a concrete feature request post it in the [discussions section](https://github.com/cardano-foundation/cardano-blueprint-and-ecosystem-monitoring/discussions) of the repository where we can refine the idea with you and create a structured feature request from it.
+If you are starting with a very vague idea instead of a concrete feature request post it in the [discussions section](https://github.com/cardano-foundation/cardano-templates/discussions) of the repository where we can refine the idea with you and create a structured feature request from it.
 
 ### Creating a pull request
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The 21 use cases identified in the research paper are as follows:
 14. [Lottery](lottery/README.md)  
 15. [Constant-product AMM](constant-product-amm/README.md)  
 16. [Upgradeable Proxy](upgradable-proxy/README.md)  
-17. [Factory](upgradable-proxy/README.md)
+17. [Factory](factory/README.md)
 18. [Decentralized identity](decentralized-identity/README.md)  
 19. [Editable NFT](editable-nft/README.md)  
 20. [Anonymous Data](anonymous-data/README.md)  


### PR DESCRIPTION
CONTRIBUTING.md still linked everywhere to the repo's old name, described CI jobs (`test-lucid` etc.) that were removed in the June matrix refactor, and pointed to issue templates that don't exist. The framework-addition steps now defer to `docs/ADDING-A-LIBRARY.md`, which is up to date.

Also fixes the README index entry for Factory, which linked to upgradable-proxy.